### PR TITLE
Replace the git dependency with the crates.io one

### DIFF
--- a/spiffe/Cargo.toml
+++ b/spiffe/Cargo.toml
@@ -9,7 +9,7 @@ openssl = "0.10.30"
 error-chain = "0.12.4"
 hyper = "0.13.8"
 protobuf = "2.18.0"
-grpcio = { git = "https://github.com/tikv/grpc-rs", rev = "b9ddf27a81d5cfef057638ffc2d02bd34d85a422", default-features = false, features = ["protobuf-codec", "openssl"] }
+grpcio = { version = "0.8.0", default-features = false, features = ["protobuf-codec", "openssl"] }
 futures = "0.3.6"
 lazy_static = "1.4.0"
 url = "2.1.1"


### PR DESCRIPTION
For grpcio. It is possible as latest `master` has been released recently!

That would allow you releasing a crates.io version of this crate and us using it in Parsec 💯 We currently have the SPIFFE functionality of Parsec on a different branch as we can not release crates with `git` dependencies...